### PR TITLE
Improve kill-ring management

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Once everything is loaded `M-x ytdious` creates a new buffer and puts it in `ytd
 | <key>S</key>        | `ytdious-search-recent`         |
 | <key>c</key>        | `ytdious-view-channel`          |
 | <key>C</key>        | `ytdious-view-channel-at-point` |
+| <key>w</key>        | `ytdious-copy-url-at-point`     |
 | <key>></key>        | `ytdious-search-next-page`      |
 | <key><</key>        | `ytdious-search-previous-page`  |
 | <key>RET</key>      | `ytdious-play`                  |
@@ -44,26 +45,7 @@ Emacs date:today
 
 mark a line and start ytdious-region-search on them, so that you don't have to remember and don't have to manually input all your searches. Also you can keep open 1 buffer per search and operate them in parralel.
 
-You can implement a function to stream a video in `mpv` (provided you have `youtube-dl` installed) as follows:
-```elisp
-(defun ytdious-watch ()
-    "Stream video at point in mpv."
-    (interactive)
-    (let* ((video (ytdious-get-current-video))
-     	   (id    (ytdious-video-id-fun video)))
-      (start-process "ytdious mpv" nil
-		     "mpv"
-		     (concat "https://www.youtube.com/watch?v=" id))
-		     "--ytdl-format=bestvideo[height<=?720]+bestaudio/best")
-      (message "Starting streaming..."))
-```
-
-And bind it to a key in `ytdious-mode` with
-```elisp
-(define-key ytdious-mode-map "y" #'ytdious-watch)
-```
-
-This is of course just an example. You can similarly implement functions to:
+Moreover, You can implement functions to:
 - open a video in the browser,
 - download a video,
 - download just the audio of a video,

--- a/ytdious.el
+++ b/ytdious.el
@@ -74,7 +74,7 @@
 (defvar ytdious-date-options (ring-convert-sequence-to-ring '(hour today week month year all))
   "Availible date options.")
 
-(defvar ytdious-invidious-api-url "https://invidio.us"
+(defvar ytdious-invidious-api-url "https://invidio.us" ;Choose a working instance
   "Url to an Invidious instance.")
 
 (defvar ytdious-invidious-default-query-fields "author,lengthSeconds,title,videoId,authorId,viewCount,published"
@@ -147,6 +147,7 @@ too long).")
     (define-key map "S" #'ytdious-search-recent)
     (define-key map "c" #'ytdious-view-channel)
     (define-key map "C" #'ytdious-view-channel-at-point)
+    (define-key map "w" #'ytdious-copy-url-at-point)
     (define-key map ">" #'ytdious-search-next-page)
     (define-key map "<" #'ytdious-search-previous-page)
     (define-key map (kbd "RET") #'ytdious-play)
@@ -234,7 +235,7 @@ Key bindings:
 		   (concat ytdious-invidious-api-url "/watch?v=" id))))
 
 (defun ytdious-show-image-asyncron ()
-    "Display Thumbnail and Titel of video on point."
+    "Display Thumbnail and Title of video on point."
     (interactive)
     (if-let ((video (ytdious-get-current-video))
 	     (id    (ytdious-video-id-fun video))
@@ -259,7 +260,7 @@ Argument TITLE video title."
       (kill-buffer buffer)
       (let* ((inhibit-read-only t))
 	(with-current-buffer popup-buffer
-			     (kill-region (point-min) (point-max))
+			     (delete-region (point-min) (point-max))
 			     (insert (format "\n%s\n\n" title))
 			     (insert-image image)
 			     (help-mode)))
@@ -277,6 +278,14 @@ Argument TITLE video title."
   (interactive)
   (forward-line -1)
   (ytdious-show-image-asyncron))
+
+(defun ytdious-copy-url-at-point ()
+  "Copy video url at point."
+  (interactive)
+  (let* ((id (tabulated-list-get-id))
+         (url (concat ytdious-invidious-api-url "/watch?v=" id)))
+    (kill-new url)
+    (message url)))
 
 (defun ytdious-quit ()
   "Quit ytdious buffer."


### PR DESCRIPTION
1. Use delete-region instead of kill-region, so kill-ring doesn't get flooded with all the titles when next-line or previous-line is called.
2. Create copy-url-at-point, which puts the url of the video in the clipboard. (bound to w by default)
3. remove example in README because it was using functions from ytel.


Suggestion : 
It would be good to update invidious.org to another healthy instance by default.